### PR TITLE
Add parameters for ERT db creds

### DIFF
--- a/ci/tasks/configure-json.yml
+++ b/ci/tasks/configure-json.yml
@@ -26,6 +26,8 @@ params:
   pcf_ert_ssl_key:
   terraform_template:
   terraform_prefix:
+  ert_sql_db_username:
+  ert_sql_db_password:
   # IaaS Specific for GCP only
   gcp_proj_id:
   gcp_region:

--- a/scripts/iaas-specific-config/gcp/run.sh
+++ b/scripts/iaas-specific-config/gcp/run.sh
@@ -21,10 +21,10 @@ gcloud_sql_instance_cmd="gcloud sql instances list --format json | jq '.[] | sel
 gcloud_sql_instance=$(eval ${gcloud_sql_instance_cmd})
 gcloud_sql_instance_ip=$(gcloud sql instances list | grep ${gcloud_sql_instance} | awk '{print$4}')
 perl -pi -e "s/{{gcloud_sql_instance_ip}}/${gcloud_sql_instance_ip}/g" ${json_file}
-perl_cmd="perl -pi -e \"s/{{gcloud_sql_instance_username}}/${pcf_opsman_admin}/g\" ${json_file}"
+perl_cmd="perl -pi -e \"s/{{gcloud_sql_instance_username}}/${ert_sql_db_username}/g\" ${json_file}"
   perl_cmd=$(echo $perl_cmd | sed 's/\@/\\@/g')
   eval $perl_cmd
-perl_cmd="perl -pi -e \"s/{{gcloud_sql_instance_password}}/${pcf_opsman_admin_passwd}/g\" ${json_file}"
+perl_cmd="perl -pi -e \"s/{{gcloud_sql_instance_password}}/${ert_sql_db_password}/g\" ${json_file}"
   perl_cmd=$(echo $perl_cmd | sed 's/\@/\\@/g')
   eval $perl_cmd
 


### PR DESCRIPTION
This fixes an issue in GCP where if the opsman and ERT DB creds are different then the pipeline fails.